### PR TITLE
Lenktoriaus pakeitimai

### DIFF
--- a/Framework/Common.cs
+++ b/Framework/Common.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium.Interactions;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+
 namespace Framework.Pages
 {
     public class Common

--- a/Framework/Driver.cs
+++ b/Framework/Driver.cs
@@ -3,6 +3,7 @@ using OpenQA.Selenium;
 using System.IO;
 using System;
 using System.Threading;
+
 namespace Framework
 {
     public class Driver

--- a/Framework/Driver.cs
+++ b/Framework/Driver.cs
@@ -13,10 +13,9 @@ namespace Framework
         public static void InitializeDriver()
         {
             ChromeOptions options = new ChromeOptions();
-            //options.AddArgument("--window-size=1920,1080");
-            //options.AddArgument("--headless");
+            options.AddArgument("--window-size=1920,1080");
+            options.AddArgument("--headless=new");
             driver.Value = new ChromeDriver(options);
-            driver.Value.Manage().Window.Maximize();
         }
 
         internal static IWebDriver GetDriver()

--- a/Framework/Driver.cs
+++ b/Framework/Driver.cs
@@ -12,9 +12,10 @@ namespace Framework
         public static void InitializeDriver()
         {
             ChromeOptions options = new ChromeOptions();
-            options.AddArgument("--window-size=1920,1080");
-            options.AddArgument("--headless=new");
+            //options.AddArgument("--window-size=1920,1080");
+            //options.AddArgument("--headless");
             driver.Value = new ChromeDriver(options);
+            driver.Value.Manage().Window.Maximize();
         }
 
         internal static IWebDriver GetDriver()

--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -57,7 +57,7 @@
     <Compile Include="Pages\Topocentras\CompareProducts.cs" />
     <Compile Include="Pages\Topocentras\LeavingAReview.cs" />
     <Compile Include="Pages\Topocentras\Locators.cs" />
-    <Compile Include="Pages\Topocentras\TopocentrasHomePage.cs" />
+    <Compile Include="Pages\Topocentras\HomePage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Framework/Pages/Topocentras/AddToCart.cs
+++ b/Framework/Pages/Topocentras/AddToCart.cs
@@ -2,11 +2,6 @@
 {
     public class AddToCart
     {
-        public static void Open()
-        {
-            Driver.OpenPage("https://www.topocentras.lt/");
-        }
-
         public static void ClickOnProduct()
         {
             Common.HoverOnElement(Locators.AddToCart.butineTechnika);
@@ -18,11 +13,6 @@
             Common.WaitUntilElementIsVisibleAndClickable(Locators.AddToCart.addToCart);
             Common.ScrollUntilElementIsClickable(Locators.AddToCart.addToCart);
             Common.ClickElementsInListAndClosePopUp(Locators.AddToCart.addToCart, Locators.AddToCart.closePopUp);
-        }
-
-        public static void CloseCookies()
-        {
-            Common.Click(Locators.AddToCart.cookies);
         }
 
         public static void GoToCart()

--- a/Framework/Pages/Topocentras/BuyingAProduct.cs
+++ b/Framework/Pages/Topocentras/BuyingAProduct.cs
@@ -2,16 +2,6 @@
 {
     public class BuyingAProduct
     {
-        public static void Open()
-        {
-            Driver.OpenPage("https://www.topocentras.lt/");
-        }
-
-        public static void CloseCookies()
-        {
-            Common.Click(Locators.AddToCart.cookies);
-        }
-
         public static void NavigateToProductPage()
         {
             Common.WaitUntilElementIsVisibleAndClickable(Locators.BuyingAProduct.telefonai);

--- a/Framework/Pages/Topocentras/CompareProducts.cs
+++ b/Framework/Pages/Topocentras/CompareProducts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 namespace Framework.Pages.Topocentras
 {
     public class CompareProducts

--- a/Framework/Pages/Topocentras/CompareProducts.cs
+++ b/Framework/Pages/Topocentras/CompareProducts.cs
@@ -3,16 +3,6 @@ namespace Framework.Pages.Topocentras
 {
     public class CompareProducts
     {
-        public static void Open()
-        {
-            Driver.OpenPage("https://www.topocentras.lt/");
-        }
-
-        public static void CloseCookies()
-        {
-            Common.Click(Locators.AddToCart.cookies);
-        }
-
         public static void ClickOnProductPage()
         {
             Common.HoverOnElement(Locators.CompareProducts.zaidimuErdve);

--- a/Framework/Pages/Topocentras/HomePage.cs
+++ b/Framework/Pages/Topocentras/HomePage.cs
@@ -8,6 +8,11 @@
             Driver.OpenPage("https://www.topocentras.lt/");
         }
 
+        public static void CloseCookies()
+        {
+            Common.Click(Locators.Home.cookies);
+        }
+
         public static void ClickPrisijungti()
         {
             Common.Click(Locators.Login.prisijungti);

--- a/Framework/Pages/Topocentras/HomePage.cs
+++ b/Framework/Pages/Topocentras/HomePage.cs
@@ -18,14 +18,14 @@
             Common.Click(Locators.Login.prisijungti);
         }
 
-        public static void EnterEmail()
+        public static void EnterEmail(string email)
         {
-            Common.SendKeys(Locators.Login.enterEmail, "baigiamasisms2023@gmail.com");
+            Common.SendKeys(Locators.Login.enterEmail, email);
         }
 
-        public static void EnterPassword()
+        public static void EnterPassword(string password)
         {
-            Common.SendKeys(Locators.Login.enterPassword, "Nesakysiu123@");
+            Common.SendKeys(Locators.Login.enterPassword, password);
         }
 
         public static void ClickPrisijungtiInLoginMenu()

--- a/Framework/Pages/Topocentras/HomePage.cs
+++ b/Framework/Pages/Topocentras/HomePage.cs
@@ -1,6 +1,6 @@
 ﻿namespace Framework.Pages.Topocentras
 {
-    public class TopocentrasHomePage
+    public class HomePage
     {
 
         public static void Open()

--- a/Framework/Pages/Topocentras/LeavingAReview.cs
+++ b/Framework/Pages/Topocentras/LeavingAReview.cs
@@ -2,16 +2,6 @@
 {
     public class LeavingAReview
     {
-        public static void Open()
-        {
-            Driver.OpenPage("https://www.topocentras.lt/");
-        }
-
-        public static void CloseCookies()
-        {
-            Common.Click(Locators.AddToCart.cookies);
-        }
-
         public static void NavigateToProductPage()
         {
             Common.HoverOnElement(Locators.LeaveAReview.televizoriai);

--- a/Framework/Pages/Topocentras/Locators.cs
+++ b/Framework/Pages/Topocentras/Locators.cs
@@ -2,6 +2,11 @@
 {
     internal static class Locators
     {
+        internal static class Home
+        {
+            internal static string cookies = "//*[@class='CookieConsent-actions-F41']";
+        }
+
         internal static class Login
         {
             internal static string prisijungti = "//*[@id='root']/header[1]/div[1]/div[1]/div[2]/button";
@@ -17,7 +22,6 @@
             internal static string butineTechnika = "(//*[@class='DesktopMenu-tabUrl-26S'])[2]";
             internal static string kaitlentes = "//*[@id='desktopMenu']/ul/li[1]/div/ul[3]/section[2]/h5[2]";
             internal static string addToCart = "(//*[@data-test-id='add-to-cart-btn'])[position()>=1 and position()<=4]";
-            internal static string cookies = "//*[@class='CookieConsent-actions-F41']";
             internal static string goToCart = "(//*[@class='Cart-checkoutLink-1fD'])[1]";
             internal static string totalProducts = "//*[@class='Products-productInfoContainer-1yU']";
             internal static string closePopUp = "//*[@class='Modal-closeButton-Ri_']";

--- a/Tests/BaseTests/BaseTest.cs
+++ b/Tests/BaseTests/BaseTest.cs
@@ -1,6 +1,8 @@
 ﻿using Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework;
+using Framework.Pages.Topocentras;
+
 namespace Tests.BaseTests
 {
     [Parallelizable]
@@ -10,6 +12,8 @@ namespace Tests.BaseTests
         public void SetUp()
         {
             Driver.InitializeDriver();
+            HomePage.Open();
+            HomePage.CloseCookies();
         }
 
         [TearDown]

--- a/Tests/Topocentras/TS01_Login.cs
+++ b/Tests/Topocentras/TS01_Login.cs
@@ -8,13 +8,15 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_LoginUsingValidData()
         {
+            string expectedResult = "Simonas";
+
             HomePage.ClickPrisijungti();
             HomePage.EnterEmail();
             HomePage.EnterPassword();
             HomePage.ClickPrisijungtiInLoginMenu();
             HomePage.ClickManoPaskyra();
-            string expectedResult = "Simonas";
             string actualResult = HomePage.ReadUserName(expectedResult);
+            
             StringAssert.Contains(expectedResult, actualResult);
         }
     }

--- a/Tests/Topocentras/TS01_Login.cs
+++ b/Tests/Topocentras/TS01_Login.cs
@@ -8,14 +8,14 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_LoginUsingValidData()
         {
-            TopocentrasHomePage.Open();
-            TopocentrasHomePage.ClickPrisijungti();
-            TopocentrasHomePage.EnterEmail();
-            TopocentrasHomePage.EnterPassword();
-            TopocentrasHomePage.ClickPrisijungtiInLoginMenu();
-            TopocentrasHomePage.ClickManoPaskyra();
+            HomePage.Open();
+            HomePage.ClickPrisijungti();
+            HomePage.EnterEmail();
+            HomePage.EnterPassword();
+            HomePage.ClickPrisijungtiInLoginMenu();
+            HomePage.ClickManoPaskyra();
             string expectedResult = "Simonas";
-            string actualResult = TopocentrasHomePage.ReadUserName(expectedResult);
+            string actualResult = HomePage.ReadUserName(expectedResult);
             StringAssert.Contains(expectedResult, actualResult);
         }
     }

--- a/Tests/Topocentras/TS01_Login.cs
+++ b/Tests/Topocentras/TS01_Login.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
 using Tests.BaseTests;
+
 namespace Tests.Topocentras
 {
     internal class TS01_Login : BaseTest

--- a/Tests/Topocentras/TS01_Login.cs
+++ b/Tests/Topocentras/TS01_Login.cs
@@ -8,7 +8,6 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_LoginUsingValidData()
         {
-            HomePage.Open();
             HomePage.ClickPrisijungti();
             HomePage.EnterEmail();
             HomePage.EnterPassword();

--- a/Tests/Topocentras/TS01_Login.cs
+++ b/Tests/Topocentras/TS01_Login.cs
@@ -1,19 +1,19 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
 using Tests.BaseTests;
-
 namespace Tests.Topocentras
 {
     internal class TS01_Login : BaseTest
     {
-        [Test]
-        public void TC01_LoginUsingValidData()
+        [TestCase("baigiamasisms2023@gmail.com", "Nesakysiu123@")]
+        public void TC01_LoginUsingValidData(string email, string password)
         {
+            
             string expectedResult = "Simonas";
 
             HomePage.ClickPrisijungti();
-            HomePage.EnterEmail();
-            HomePage.EnterPassword();
+            HomePage.EnterEmail(email);
+            HomePage.EnterPassword(password);
             HomePage.ClickPrisijungtiInLoginMenu();
             HomePage.ClickManoPaskyra();
             string actualResult = HomePage.ReadUserName(expectedResult);

--- a/Tests/Topocentras/TS02_AddProductsToCart.cs
+++ b/Tests/Topocentras/TS02_AddProductsToCart.cs
@@ -8,11 +8,13 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_AddProductsToCart()
         {
+            string expectedResult = "4";
+
             AddToCart.ClickOnProduct();
             AddToCart.AddProductsToCart();
             AddToCart.GoToCart();
             string actualResult = AddToCart.GetTotalProducts();
-            string expectedResult = "4";
+            
             Assert.AreEqual(expectedResult, actualResult);
         }
     }

--- a/Tests/Topocentras/TS02_AddProductsToCart.cs
+++ b/Tests/Topocentras/TS02_AddProductsToCart.cs
@@ -8,8 +8,6 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_AddProductsToCart()
         {
-            AddToCart.Open();
-            AddToCart.CloseCookies();
             AddToCart.ClickOnProduct();
             AddToCart.AddProductsToCart();
             AddToCart.GoToCart();

--- a/Tests/Topocentras/TS02_AddProductsToCart.cs
+++ b/Tests/Topocentras/TS02_AddProductsToCart.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
 using Tests.BaseTests;
+
 namespace Tests.Topocentras
 {
     internal class TS02_AddProductsToCart : BaseTest

--- a/Tests/Topocentras/TS03_CompareProducts.cs
+++ b/Tests/Topocentras/TS03_CompareProducts.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using Tests.BaseTests;
+
 namespace Tests.Topocentras
 {
     internal class TS03_CompareProducts : BaseTest

--- a/Tests/Topocentras/TS03_CompareProducts.cs
+++ b/Tests/Topocentras/TS03_CompareProducts.cs
@@ -8,8 +8,6 @@ namespace Tests.Topocentras
         [Test]
         public void TC01_CompareThreeProducts()
         {
-            CompareProducts.Open();
-            CompareProducts.CloseCookies();
             CompareProducts.ClickOnProductPage();
             CompareProducts.AddProductsToCompare();
             CompareProducts.GoToComparePage();

--- a/Tests/Topocentras/TS03_CompareProducts.cs
+++ b/Tests/Topocentras/TS03_CompareProducts.cs
@@ -1,5 +1,6 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
+using System.Collections.Generic;
 using Tests.BaseTests;
 namespace Tests.Topocentras
 {
@@ -11,7 +12,9 @@ namespace Tests.Topocentras
             CompareProducts.ClickOnProductPage();
             CompareProducts.AddProductsToCompare();
             CompareProducts.GoToComparePage();
-            Assert.That(CompareProducts.GetElementText(), Is.Unique);
+            List<string> productNames = CompareProducts.GetElementText();
+
+            Assert.That(productNames, Is.Unique);
         }
     }
 }

--- a/Tests/Topocentras/TS04_LeaveAReview.cs
+++ b/Tests/Topocentras/TS04_LeaveAReview.cs
@@ -9,8 +9,6 @@ namespace Tests.Topocentras
         public void TC01_LeaveA5StarReview()
         {
             string expectedResult = "Jūsų apžvalga pateikta!";
-            LeavingAReview.Open();
-            LeavingAReview.CloseCookies();
             LeavingAReview.NavigateToProductPage();
             LeavingAReview.WriteAReview();
             string actualResult = LeavingAReview.GetReviewConfirmation(expectedResult);

--- a/Tests/Topocentras/TS04_LeaveAReview.cs
+++ b/Tests/Topocentras/TS04_LeaveAReview.cs
@@ -9,9 +9,11 @@ namespace Tests.Topocentras
         public void TC01_LeaveA5StarReview()
         {
             string expectedResult = "Jūsų apžvalga pateikta!";
+            
             LeavingAReview.NavigateToProductPage();
             LeavingAReview.WriteAReview();
             string actualResult = LeavingAReview.GetReviewConfirmation(expectedResult);
+            
             StringAssert.Contains(expectedResult, actualResult);
         }
     }

--- a/Tests/Topocentras/TS04_LeaveAReview.cs
+++ b/Tests/Topocentras/TS04_LeaveAReview.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
 using Tests.BaseTests;
+
 namespace Tests.Topocentras
 {
     internal class TS04_LeaveAReview : BaseTest

--- a/Tests/Topocentras/TS05_BuyAProduct.cs
+++ b/Tests/Topocentras/TS05_BuyAProduct.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Pages.Topocentras;
 using NUnit.Framework;
 using Tests.BaseTests;
+
 namespace Tests.Topocentras
 {
     internal class TS05_BuyAProduct : BaseTest

--- a/Tests/Topocentras/TS05_BuyAProduct.cs
+++ b/Tests/Topocentras/TS05_BuyAProduct.cs
@@ -9,8 +9,6 @@ namespace Tests.Topocentras
         public void TC01_BuyAProductWhileLoggedIn()
         {
             string expectedResult = "Patvirtinti užsakymą";
-            BuyingAProduct.Open();
-            BuyingAProduct.CloseCookies();
             BuyingAProduct.NavigateToProductPage();
             BuyingAProduct.AddProductToCart();
             BuyingAProduct.GoToCheckOut();

--- a/Tests/Topocentras/TS05_BuyAProduct.cs
+++ b/Tests/Topocentras/TS05_BuyAProduct.cs
@@ -9,6 +9,7 @@ namespace Tests.Topocentras
         public void TC01_BuyAProductWhileLoggedIn()
         {
             string expectedResult = "Patvirtinti užsakymą";
+            
             BuyingAProduct.NavigateToProductPage();
             BuyingAProduct.AddProductToCart();
             BuyingAProduct.GoToCheckOut();
@@ -16,6 +17,7 @@ namespace Tests.Topocentras
             BuyingAProduct.LogIn();
             BuyingAProduct.FinishCheckOut();
             string actualResult = BuyingAProduct.CheckIfSubmitOrderReached();
+            
             Assert.AreEqual(expectedResult, actualResult);
         }
     }


### PR DESCRIPTION
Tinkama:

- Išpildyti visi baigiamojo darbo reikalavimai
- Tvarkingai aprašyti testavimo atvejai
- Tvarkinga POM struktūra
- Prasmingos commit žinutės

Keistina:

- Ne visi testai stabilūs, leidžiant kelis kartus kartais pass'ina, kartais fail'ina. Reikėtų daugiau pasigilinti kodėl kartais testai stringa ir greičiausiai padaryti papildomus laukimus.
- Vengiama tuščių eilučių nors saikingas jų naudojimas padeda skaitomumui (atskirti namespace nuo imports, atskirti Assert dalį teste, atskirti duomenis nuo veiksmų teste, atskirti metodo return dalį ir panašiai) Nors čia turbūt skonio reikalas :)
- Čia taip pat gal skonio reikalas, bet mano nuomone yra logiška testo pradžioje turėti duomenis, toliau veiksmus ir tada Assert. Pas jus testo duomenys būna prieš Assert. Logika turėti duomenis testo pradžioje yra pvz ta, kad jeigu ateity atliktumėte testo parametrizavimą (TestCase anotacija), tuomet būtų lengviau neklaidžioti ir nedarant klaidų iškelti duomenis iš testo į metodo aprašymą
- TC01_LoginUsingValidData teste duomenys (email ir password) yra "hardcoded" į POM metodus. Čia jau tikrai bloga praktika :). Pvz jeigu turėtumėte kelis skirtingus vartotojus (user ir admin) ir jie turi skirtingas paskyras ir galbūt skiriasi expectedResult prisijungus ir reikėtų dviejų testų tai jūsų atveju negalėtumėte perpanaudoti POM metodų kitai anketai
- Skaitant testo TC01_AddProductsToCart kodą sunku suprasti ką tiksliai testas daro, reikia nueiti iki pat lokatoriaus tam, kad suprasti, kad bus pridedami keturi pirmi produktai. Tai galėtų atsispindėti pačiame POM metode (AddToCart.AddProductsToCart()) pakeičiant jį, į pvz AddProductsFromIndexToIndexToCart(int indexFrom, int indexTo). Tokiu atveju ir pats metodas taptų universalesnis.
- Metodai Open ir CloseCookies visuose testuose yra vienodi. Testas gali kviesti metodus iš kelių skirtingų POM klasių. Net jeigu Open metodai ir skirtųsi (atidarytų šiek tiek skirtingus tos pačios svetainės puslapius), CloseCookies metodas greičiausiai vis tiek būtų tas pats visiems puslapiams. Tai principe visi testai gali kviesti šiuos metodus iš HomePage. Ir netgi jie visi gali tai atlikti iš base klasės
- Kažkaip pastebėjau, kad "--headless=new" padaro taip, kad matosi ta lentelė kur prašo allow ar decline, kad svetainė galėtų rodytų notifications o su "--headless" jos nesimato, bent jau pas mane. Panašu, kad "--headless=new" yra kažkoks bug, bent jau šiai dienai